### PR TITLE
Remove wrong ORCID ID

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,6 @@ authors:
   - family-names: Traylor
     given-names: Wolfgang
     affiliation: Senckenberg Biodiversity and Climate Research Centre
-    orcid: https://orcid.org/0000-0003-4925-7248
 title: "Modular Megafauna Model"
 version: 1.1.4
 # This DOI represents all versions, and will always resolve to the latest one.


### PR DESCRIPTION
- Remove my ORCID ID (probably a leftover from pasting a template/example), as I'm not @wtraylor :).

This popped up because DataCite (the DOI minter behind Zenodo) changed my ORCID record to add the v1.1.4 release to my publications. I should probably replace my real ORCID with an unresovable dummy in `CITATION.cff` examples.

Good luck with this project, it sounds really interesting, and the README is great!